### PR TITLE
Remove the noisy output when go building.

### DIFF
--- a/hack/build/agent.sh
+++ b/hack/build/agent.sh
@@ -25,16 +25,16 @@ echo "after GOROOT=$GOROOT    GOPATH=$GOPATH  GO=$GO   KNITTERPATH=${KNITTERPATH
 
 if [ ${OPERATION} = "build" ];then
 	############## build begin ##############
-	echo "============== build operation =============="
+	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-agent
 	${GO}/go clean
-	${GO}/go build -v -x -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
+	${GO}/go build -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
 
 	if [ -f ${KNITTERPATH}/knitter-agent/knitter-agent ];then
-		echo "compare agent.."    
+		echo "++++ build ${MODULENAME} success"
 		exit 0
 	else
-		echo "++++ build_agent:: error knitter-agent is not exit"
+		echo "++++ build_agent:: error knitter-agent is not existing"
 		exit 1
 	fi
 

--- a/hack/build/manager.sh
+++ b/hack/build/manager.sh
@@ -23,15 +23,15 @@ echo "after GOROOT=$GOROOT    GOPATH=$GOPATH  GO=$GO   KNITTERPATH=${KNITTERPATH
 
 if [ ${OPERATION} = "build" ];then
 	############## build begin ##############
-	echo "============== build operation =============="
+	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-manager
 	${GO}/go clean
-	${GO}/go build -v -x -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
+	${GO}/go build -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
 	if [ -f ${KNITTERPATH}/knitter-manager/knitter-manager ];then
-			echo "++++ build manager success"  
+			echo "++++ build ${MODULENAME} success"
 			exit 0
 	else
-			echo "++++ build_manager:: error knitter-manager is not exit"
+			echo "++++ build_manager:: error knitter-manager is not existing"
 			exit 1
 	fi
 fi

--- a/hack/build/monitor.sh
+++ b/hack/build/monitor.sh
@@ -23,12 +23,12 @@ echo "after GOROOT=$GOROOT    GOPATH=$GOPATH  GO=$GO   KNITTERPATH=${KNITTERPATH
 
 if [ ${OPERATION} = "build" ];then
 	############## build begin ##############
-	echo "============== build operation =============="
+	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-monitor
 	${GO}/go clean
-	${GO}/go build -v -x -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
+	${GO}/go build -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
 	if [ -f ${KNITTERPATH}/knitter-monitor/knitter-monitor ];then
-			echo "++++ build monitor success"  
+			echo "++++ build ${MODULENAME} success"
 			exit 0
 	else
 			echo "++++ build_moritor:: error knitter-monitor is not exit"

--- a/hack/build/plugin.sh
+++ b/hack/build/plugin.sh
@@ -24,13 +24,13 @@ echo "after GOROOT=$GOROOT    GOPATH=$GOPATH  GO=$GO   KNITTERPATH=${KNITTERPATH
 
 if [ ${OPERATION} = "build" ];then
 	############## build begin ##############
-	echo "============== build operation =============="
+	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-plugin
 	${GO}/go clean
-	${GO}/go build -o knitter-plugin -v -x -ldflags "-X github.com/ZTE/Knitter/pkg/version.moduleName=${MODULENAME} -X github.com/ZTE/Knitter/pkg/version.verType=${VERTYPE} -X github.com/ZTE/Knitter/pkg/version.versionInfo=${BRANCH_VERSION} -X github.com/ZTE/Knitter/pkg/version.gitHash=${GITHASH} -X github.com/ZTE/Knitter/pkg/version.buildTime=${BUILDTIME}"
+	${GO}/go build -o knitter-plugin -ldflags "-X github.com/ZTE/Knitter/pkg/version.moduleName=${MODULENAME} -X github.com/ZTE/Knitter/pkg/version.verType=${VERTYPE} -X github.com/ZTE/Knitter/pkg/version.versionInfo=${BRANCH_VERSION} -X github.com/ZTE/Knitter/pkg/version.gitHash=${GITHASH} -X github.com/ZTE/Knitter/pkg/version.buildTime=${BUILDTIME}"
 
 	if [ -f ${KNITTERPATH}/knitter-plugin/knitter-plugin ];then
-		echo "++++ build plugin:: build plugin"
+		echo "++++ build ${MODULENAME} success"
 		exit 0			
 	else
 		echo "++++ build plugin:: error plugin not exist"


### PR DESCRIPTION
**Why we need this PR**:
There are so many noisy output when go build running. We should remove them.

**Which issue(s) this PR fixes(we suggest there is at least one issue related to this PR)**
Fixes # NONE

/cc @guangxuli 

