### PR TITLE
Comment knitter agent get pod error.

### DIFF
--- a/knitter-agent/context/get_pod_action.go
+++ b/knitter-agent/context/get_pod_action.go
@@ -67,7 +67,7 @@ func (this *GetPodAction) Exec(transInfo *transdsl.TransInfo) (err error) {
 	}
 	if err != nil {
 		klog.Errorf("GetPod info error: %v", err)
-		return errors.New("GetPodAction:GetPod error")
+		//return errors.New("GetPodAction:GetPod error")
 	}
 
 	podObj, err := podobj.CreatePodObj(knitterObj.CniParam, monitorPod)


### PR DESCRIPTION
This fixes a bug (I didn't recall the detail) when agent fails to get pod. This can be optimized in the future.

cc @guangxuli 