### PR TITLE
Optimize compiling scripts.

### DIFF
--- a/hack/build/agent.sh
+++ b/hack/build/agent.sh
@@ -28,7 +28,7 @@ if [ ${OPERATION} = "build" ];then
 	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-agent
 	${GO}/go clean
-	${GO}/go build -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
+	CGO_ENABLED=0 ${GO}/go build -ldflags '-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME} -extldflags "-static"'
 
 	if [ -f ${KNITTERPATH}/knitter-agent/knitter-agent ];then
 		echo "++++ build ${MODULENAME} success"

--- a/hack/build/manager.sh
+++ b/hack/build/manager.sh
@@ -26,7 +26,7 @@ if [ ${OPERATION} = "build" ];then
 	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-manager
 	${GO}/go clean
-	${GO}/go build -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
+	CGO_ENABLED=0 ${GO}/go build -ldflags '-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME} -extldflags "-static"'
 	if [ -f ${KNITTERPATH}/knitter-manager/knitter-manager ];then
 			echo "++++ build ${MODULENAME} success"
 			exit 0

--- a/hack/build/monitor.sh
+++ b/hack/build/monitor.sh
@@ -26,7 +26,7 @@ if [ ${OPERATION} = "build" ];then
 	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-monitor
 	${GO}/go clean
-	${GO}/go build -ldflags "-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME}"
+	CGO_ENABLED=0 ${GO}/go build -ldflags '-X ${BUILDPKG}/pkg/version.moduleName=${MODULENAME} -X ${BUILDPKG}/pkg/version.verType=${VERTYPE} -X ${BUILDPKG}/pkg/version.versionInfo=${BRANCH_VERSION} -X ${BUILDPKG}/pkg/version.gitHash=${GITHASH} -X ${BUILDPKG}/pkg/version.buildTime=${BUILDTIME} -extldflags "-static"'
 	if [ -f ${KNITTERPATH}/knitter-monitor/knitter-monitor ];then
 			echo "++++ build ${MODULENAME} success"
 			exit 0

--- a/hack/build/plugin.sh
+++ b/hack/build/plugin.sh
@@ -27,7 +27,7 @@ if [ ${OPERATION} = "build" ];then
 	echo "============== building ${MODULENAME} =============="
 	cd  ${KNITTERPATH}/knitter-plugin
 	${GO}/go clean
-	${GO}/go build -o knitter-plugin -ldflags "-X github.com/ZTE/Knitter/pkg/version.moduleName=${MODULENAME} -X github.com/ZTE/Knitter/pkg/version.verType=${VERTYPE} -X github.com/ZTE/Knitter/pkg/version.versionInfo=${BRANCH_VERSION} -X github.com/ZTE/Knitter/pkg/version.gitHash=${GITHASH} -X github.com/ZTE/Knitter/pkg/version.buildTime=${BUILDTIME}"
+	CGO_ENABLED=0 ${GO}/go build -o knitter-plugin -ldflags '-X github.com/ZTE/Knitter/pkg/version.moduleName=${MODULENAME} -X github.com/ZTE/Knitter/pkg/version.verType=${VERTYPE} -X github.com/ZTE/Knitter/pkg/version.versionInfo=${BRANCH_VERSION} -X github.com/ZTE/Knitter/pkg/version.gitHash=${GITHASH} -X github.com/ZTE/Knitter/pkg/version.buildTime=${BUILDTIME} -extldflags "-static"'
 
 	if [ -f ${KNITTERPATH}/knitter-plugin/knitter-plugin ];then
 		echo "++++ build ${MODULENAME} success"


### PR DESCRIPTION
Without this patch, the binaries cannot be run in container. Users will get an error something like `knitter-manager: not found`

/cc @guangxuli 